### PR TITLE
eq_google_shopping_feed: Bugfix empty description sale

### DIFF
--- a/eq_google_shopping_feed/controllers.py
+++ b/eq_google_shopping_feed/controllers.py
@@ -211,6 +211,9 @@ class EqGoogleShoppingFeed(http.Controller):
                 elif contry_code == 'en':
                     price = str(product_obj.list_price) + ' USD'
                     country ='US'
+                elif contry_code == 'ch':
+                    price = str(product_obj.list_price) + ' CHF'
+                    country = 'CH'
                 availability = product_obj.qty_available                                                            #Stock
                 if product_obj.weight_net != False and product_obj.eq_basic.name != False:
                     #unit_measure = str(product_obj.weight_net) + ' ' + product_obj.eq_basic.name                    #Grundpreis Maß

--- a/eq_google_shopping_feed/controllers.py
+++ b/eq_google_shopping_feed/controllers.py
@@ -172,7 +172,7 @@ class EqGoogleShoppingFeed(http.Controller):
             title = product.name                                            # titel
             
             
-            description_1 = product.description_sale                        # description - original
+            description_1 = product.description_sale or ''                  # description - original
             
             description_2 = description_1.replace("%", "&#37;")
             description_3 = description_2.replace("<", "&lt;")


### PR DESCRIPTION
When no sale description is set the feed generation will fail. So the NULL value of description_sale is replaced with an empty string.