### PR TITLE
eq_google_shopping_feed: Bugfix title not escaped

### DIFF
--- a/eq_google_shopping_feed/controllers.py
+++ b/eq_google_shopping_feed/controllers.py
@@ -170,6 +170,10 @@ class EqGoogleShoppingFeed(http.Controller):
             product_product = http.request.env['product.product'].sudo().search([('product_tmpl_id', '=', id)])
             
             title = product.name                                            # titel
+            title = title.replace("%", "&#37;")
+            title = title.replace("<", "&lt;")
+            title = title.replace(">", "&gt;")
+            title = title.replace("&", "&amp;")
             
             
             description_1 = product.description_sale or ''                  # description - original


### PR DESCRIPTION
When products have special characters in name (e.g. "Body & More") the generated xml file is invalid. 
Now the title is escaped like the description.